### PR TITLE
Upgrade libp2p to enable yamux gains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "discv5"
 version = "0.4.0"
-source = "git+https://github.com/sigp/discv5?rev=87a0260db8a27595d01999ea5850848c43cc1bf0#87a0260db8a27595d01999ea5850848c43cc1bf0"
+source = "git+https://github.com/sigp/discv5?rev=1b5218d01015023f32e12c0a9ac6780759a550bf#1b5218d01015023f32e12c0a9ac6780759a550bf"
 dependencies = [
  "aes 0.7.5",
  "aes-gcm 0.9.2",
@@ -2851,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "futures-bounded"
 version = "0.2.3"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -4063,8 +4063,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p"
-version = "0.53.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+version = "0.53.2"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "bytes",
  "either",
@@ -4097,7 +4097,7 @@ dependencies = [
 [[package]]
 name = "libp2p-allow-block-list"
 version = "0.3.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4107,8 +4107,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.3.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+version = "0.3.1"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
@@ -4118,8 +4118,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.41.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+version = "0.41.2"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "either",
  "fnv",
@@ -4146,7 +4146,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.41.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "async-trait",
  "futures",
@@ -4161,7 +4161,7 @@ dependencies = [
 [[package]]
 name = "libp2p-gossipsub"
 version = "0.46.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "async-channel",
  "asynchronous-codec",
@@ -4193,7 +4193,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.44.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mdns"
 version = "0.45.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "data-encoding",
  "futures",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "libp2p-metrics"
 version = "0.14.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "futures",
  "instant",
@@ -4274,7 +4274,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.41.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.44.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4317,7 +4317,7 @@ dependencies = [
 [[package]]
 name = "libp2p-plaintext"
 version = "0.41.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -4331,8 +4331,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.10.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+version = "0.10.2"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "bytes",
  "futures",
@@ -4354,8 +4354,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.44.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+version = "0.44.1"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "either",
  "fnv",
@@ -4376,8 +4376,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm-derive"
-version = "0.34.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+version = "0.34.1"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4388,7 +4388,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.41.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4404,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.3.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "libp2p-upnp"
 version = "0.2.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "futures",
  "futures-timer",
@@ -4437,13 +4437,15 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.45.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
+ "either",
  "futures",
  "libp2p-core",
  "thiserror",
  "tracing",
- "yamux",
+ "yamux 0.12.1",
+ "yamux 0.13.1",
 ]
 
 [[package]]
@@ -5044,7 +5046,7 @@ dependencies = [
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "bytes",
  "futures",
@@ -6139,7 +6141,7 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "asynchronous-codec",
  "bytes",
@@ -6719,7 +6721,7 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "git+https://github.com/sigp/rust-libp2p/?rev=a70bef04c0c3e1dc35b812a597bb66ca89788e36#a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+source = "git+https://github.com/sigp/rust-libp2p/?rev=c5430243501075eba4429b33c427bc0ed13d0ff6#c5430243501075eba4429b33c427bc0ed13d0ff6"
 dependencies = [
  "futures",
  "pin-project",
@@ -9273,6 +9275,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
 dependencies = [
  "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.1",
+ "pin-project",
+ "rand",
+ "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1d0148b89300047e72994bee99ecdabd15a9166a7b70c8b8c37c314dcc9002"
+dependencies = [
+ "futures",
+ "instant",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ criterion = "0.3"
 delay_map = "0.3"
 derivative = "2"
 dirs = "3"
-discv5 = { git="https://github.com/sigp/discv5", rev="87a0260db8a27595d01999ea5850848c43cc1bf0", features = ["libp2p"] }
+discv5 = { git="https://github.com/sigp/discv5", rev="1b5218d01015023f32e12c0a9ac6780759a550bf", features = ["libp2p"] }
 env_logger = "0.9"
 error-chain = "0.12"
 ethereum-types = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ criterion = "0.3"
 delay_map = "0.3"
 derivative = "2"
 dirs = "3"
+# Branch https://github.com/sigp/discv5/tree/lighthouse-with-yamux
 discv5 = { git="https://github.com/sigp/discv5", rev="1b5218d01015023f32e12c0a9ac6780759a550bf", features = ["libp2p"] }
 env_logger = "0.9"
 error-chain = "0.12"

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -43,11 +43,11 @@ prometheus-client = "0.22.0"
 unused_port = { workspace = true }
 delay_map = { workspace = true }
 void = "1"
-libp2p-mplex = { git = "https://github.com/sigp/rust-libp2p/", rev = "a70bef04c0c3e1dc35b812a597bb66ca89788e36"}
+libp2p-mplex = { git = "https://github.com/sigp/rust-libp2p/", rev = "c5430243501075eba4429b33c427bc0ed13d0ff6"}
 
 [dependencies.libp2p]
 git = "https://github.com/sigp/rust-libp2p/"
-rev = "a70bef04c0c3e1dc35b812a597bb66ca89788e36"
+rev = "c5430243501075eba4429b33c427bc0ed13d0ff6"
 default-features = false
 features = ["identify", "yamux", "noise", "gossipsub", "dns", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic"]
 

--- a/beacon_node/lighthouse_network/Cargo.toml
+++ b/beacon_node/lighthouse_network/Cargo.toml
@@ -47,6 +47,7 @@ libp2p-mplex = { git = "https://github.com/sigp/rust-libp2p/", rev = "c543024350
 
 [dependencies.libp2p]
 git = "https://github.com/sigp/rust-libp2p/"
+# Branch https://github.com/sigp/rust-libp2p/tree/lighthouse-gossipsub-yamux
 rev = "c5430243501075eba4429b33c427bc0ed13d0ff6"
 default-features = false
 features = ["identify", "yamux", "noise", "gossipsub", "dns", "tcp", "tokio", "plaintext", "secp256k1", "macros", "ecdsa", "metrics", "quic"]


### PR DESCRIPTION
## Issue Addressed

N/A

## Proposed Changes

Upgrade to a libp2p sigp branch which contains the yamux improvements. The libp2p branch is essentially the commit being used in @jxs 's PR merged with libp2p master.
Also upgrades to a discv5 branch that uses the updated libp2p commit.

Libp2p branch: https://github.com/sigp/rust-libp2p/tree/lighthouse-gossipsub-yamux
Discv5 branch: https://github.com/sigp/discv5/tree/lighthouse-with-yamux

Related https://github.com/sigp/lighthouse/pull/4996
