### PR TITLE
Add ipv4/ipv6 peers metric

### DIFF
--- a/beacon_node/lighthouse_network/src/metrics.rs
+++ b/beacon_node/lighthouse_network/src/metrics.rs
@@ -24,6 +24,16 @@ lazy_static! {
         "Count of libp2p peers currently connected via QUIC"
     );
 
+    pub static ref IP4_PEERS_CONNECTED: Result<IntGauge> = try_create_int_gauge(
+        "libp2p_ipv4_peers",
+        "Count of libp2p peers currently connected over IPv4"
+    );
+
+    pub static ref IP6_PEERS_CONNECTED: Result<IntGauge> = try_create_int_gauge(
+        "libp2p_ipv6_peers",
+        "Count of libp2p peers currently connected over IPv6"
+    );
+
     pub static ref PEER_CONNECT_EVENT_COUNT: Result<IntCounter> = try_create_int_counter(
         "libp2p_peer_connect_event_total",
         "Count of libp2p peer connect events (not the current number of connected peers)"

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -248,7 +248,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             match remote_addr.iter().find(|proto| {
                 matches!(
                     proto,
-                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip(_) | multiaddr::Protocol::Dns(_)
+                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip4 | multiaddr::Protocol::Ip6 | multiaddr::Protocol::Dns | multiaddr::Protocol::Dns4 | multiaddr::Protocol::Dns6
                 )
             }) {
                 Some(multiaddr::Protocol::QuicV1) => {
@@ -257,10 +257,19 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 Some(multiaddr::Protocol::Tcp(_)) => {
                     metrics::inc_gauge(&metrics::TCP_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Ip4 | multiaddr::Protocol::Dns4) => {
+                Some(multiaddr::Protocol::Ip4) => {
                     metrics::inc_gauge(&metrics::IP4_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Ip6 | multiaddr::Protocol::Dns6) => {
+                Some(multiaddr::Protocol::Dns) => {
+                    metrics::inc_gauge(&metrics::IP4_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Dns4) => {
+                    metrics::inc_gauge(&metrics::IP4_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Ip6) => {
+                    metrics::inc_gauge(&metrics::IP6_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Dns6) => {
                     metrics::inc_gauge(&metrics::IP6_PEERS_CONNECTED);
                 }
                 Some(_) => unreachable!(),
@@ -342,7 +351,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             match remote_addr.iter().find(|proto| {
                 matches!(
                     proto,
-                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip(_) | multiaddr::Protocol::Dns(_)
+                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip4 | multiaddr::Protocol::Ip6 | multiaddr::Protocol::Dns | multiaddr::Protocol::Dns4 | multiaddr::Protocol::Dns6
                 )
             }) {
                 Some(multiaddr::Protocol::QuicV1) => {
@@ -351,10 +360,19 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 Some(multiaddr::Protocol::Tcp(_)) => {
                     metrics::dec_gauge(&metrics::TCP_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Ip4 | multiaddr::Protocol::Dns4) => {
+                Some(multiaddr::Protocol::Ip4) => {
                     metrics::dec_gauge(&metrics::IP4_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Ip6 | multiaddr::Protocol::Dns6) => {
+                Some(multiaddr::Protocol::Dns) => {
+                    metrics::dec_gauge(&metrics::IP4_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Dns4) => {
+                    metrics::dec_gauge(&metrics::IP4_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Ip6) => {
+                    metrics::dec_gauge(&metrics::IP6_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Dns6) => {
                     metrics::dec_gauge(&metrics::IP6_PEERS_CONNECTED);
                 }
                 // If it's an unknown protocol we already logged when connection was established.

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -248,7 +248,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             match remote_addr.iter().find(|proto| {
                 matches!(
                     proto,
-                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip4 | multiaddr::Protocol::Ip6 | multiaddr::Protocol::Dns | multiaddr::Protocol::Dns4 | multiaddr::Protocol::Dns6
+                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip4(_) | multiaddr::Protocol::Ip6(_) | multiaddr::Protocol::Dns(_) | multiaddr::Protocol::Dns4(_) | multiaddr::Protocol::Dns6(_)
                 )
             }) {
                 Some(multiaddr::Protocol::QuicV1) => {
@@ -257,19 +257,19 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 Some(multiaddr::Protocol::Tcp(_)) => {
                     metrics::inc_gauge(&metrics::TCP_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Ip4) => {
+                Some(multiaddr::Protocol::Ip4(_)) => {
                     metrics::inc_gauge(&metrics::IP4_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Dns) => {
+                Some(multiaddr::Protocol::Dns(_)) => {
                     metrics::inc_gauge(&metrics::IP4_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Dns4) => {
+                Some(multiaddr::Protocol::Dns4(_)) => {
                     metrics::inc_gauge(&metrics::IP4_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Ip6) => {
+                Some(multiaddr::Protocol::Ip6(_)) => {
                     metrics::inc_gauge(&metrics::IP6_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Dns6) => {
+                Some(multiaddr::Protocol::Dns6(_)) => {
                     metrics::inc_gauge(&metrics::IP6_PEERS_CONNECTED);
                 }
                 Some(_) => unreachable!(),
@@ -351,7 +351,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             match remote_addr.iter().find(|proto| {
                 matches!(
                     proto,
-                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip4 | multiaddr::Protocol::Ip6 | multiaddr::Protocol::Dns | multiaddr::Protocol::Dns4 | multiaddr::Protocol::Dns6
+                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip4(_) | multiaddr::Protocol::Ip6(_) | multiaddr::Protocol::Dns(_) | multiaddr::Protocol::Dns4(_) | multiaddr::Protocol::Dns6(_)
                 )
             }) {
                 Some(multiaddr::Protocol::QuicV1) => {
@@ -360,19 +360,19 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 Some(multiaddr::Protocol::Tcp(_)) => {
                     metrics::dec_gauge(&metrics::TCP_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Ip4) => {
+                Some(multiaddr::Protocol::Ip4(_)) => {
                     metrics::dec_gauge(&metrics::IP4_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Dns) => {
+                Some(multiaddr::Protocol::Dns(_)) => {
                     metrics::dec_gauge(&metrics::IP4_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Dns4) => {
+                Some(multiaddr::Protocol::Dns4(_)) => {
                     metrics::dec_gauge(&metrics::IP4_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Ip6) => {
+                Some(multiaddr::Protocol::Ip6(_)) => {
                     metrics::dec_gauge(&metrics::IP6_PEERS_CONNECTED);
                 }
-                Some(multiaddr::Protocol::Dns6) => {
+                Some(multiaddr::Protocol::Dns6(_)) => {
                     metrics::dec_gauge(&metrics::IP6_PEERS_CONNECTED);
                 }
                 // If it's an unknown protocol we already logged when connection was established.

--- a/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
+++ b/beacon_node/lighthouse_network/src/peer_manager/network_behaviour.rs
@@ -248,7 +248,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             match remote_addr.iter().find(|proto| {
                 matches!(
                     proto,
-                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_)
+                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip(_) | multiaddr::Protocol::Dns(_)
                 )
             }) {
                 Some(multiaddr::Protocol::QuicV1) => {
@@ -256,6 +256,12 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 }
                 Some(multiaddr::Protocol::Tcp(_)) => {
                     metrics::inc_gauge(&metrics::TCP_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Ip4 | multiaddr::Protocol::Dns4) => {
+                    metrics::inc_gauge(&metrics::IP4_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Ip6 | multiaddr::Protocol::Dns6) => {
+                    metrics::inc_gauge(&metrics::IP6_PEERS_CONNECTED);
                 }
                 Some(_) => unreachable!(),
                 None => {
@@ -336,7 +342,7 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
             match remote_addr.iter().find(|proto| {
                 matches!(
                     proto,
-                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_)
+                    multiaddr::Protocol::QuicV1 | multiaddr::Protocol::Tcp(_) | multiaddr::Protocol::Ip(_) | multiaddr::Protocol::Dns(_)
                 )
             }) {
                 Some(multiaddr::Protocol::QuicV1) => {
@@ -344,6 +350,12 @@ impl<TSpec: EthSpec> PeerManager<TSpec> {
                 }
                 Some(multiaddr::Protocol::Tcp(_)) => {
                     metrics::dec_gauge(&metrics::TCP_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Ip4 | multiaddr::Protocol::Dns4) => {
+                    metrics::dec_gauge(&metrics::IP4_PEERS_CONNECTED);
+                }
+                Some(multiaddr::Protocol::Ip6 | multiaddr::Protocol::Dns6) => {
+                    metrics::dec_gauge(&metrics::IP6_PEERS_CONNECTED);
                 }
                 // If it's an unknown protocol we already logged when connection was established.
                 _ => {}


### PR DESCRIPTION
## Issue Addressed

expose a new metric (ipv4 peers/ ipv6 peers) to have a better view on ipv6 adoption


## Additional Info

useful for [issue #4924](https://github.com/sigp/lighthouse/issues/4924)