### PR TITLE
Fix `test_ignore_too_many_messages_in_ihave` test

### DIFF
--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
@@ -4585,9 +4585,9 @@ fn test_ignore_too_many_messages_in_ihave() {
     let (peer, receiver) = add_peer(&mut gs, &topics, false, false);
     receivers.insert(peer, receiver);
 
-    //peer has 20 messages
+    //peer has 30 messages
     let mut seq = 0;
-    let message_ids: Vec<_> = (0..20)
+    let message_ids: Vec<_> = (0..30)
         .map(|_| random_message(&mut seq, &topics))
         .map(|msg| gs.data_transform.inbound_transform(msg).unwrap())
         .map(|msg| config.message_id(&msg))
@@ -4629,7 +4629,7 @@ fn test_ignore_too_many_messages_in_ihave() {
     gs.heartbeat();
     gs.handle_ihave(
         &peer,
-        vec![(topics[0].clone(), message_ids[10..20].to_vec())],
+        vec![(topics[0].clone(), message_ids[20..30].to_vec())],
     );
 
     //we sent 10 iwant messages ids via a IWANT rpc.

--- a/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
+++ b/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs
@@ -5252,7 +5252,7 @@ fn sends_idontwant() {
         .to_subscribe(true)
         .gs_config(Config::default())
         .explicit(1)
-        .peer_kind(PeerKind::Gossipsubv1_2)
+        .peer_kind(PeerKind::Gossipsubv1_2_beta)
         .create_network();
 
     let local_id = PeerId::random();
@@ -5337,7 +5337,7 @@ fn doesnt_forward_idontwant() {
         .to_subscribe(true)
         .gs_config(Config::default())
         .explicit(1)
-        .peer_kind(PeerKind::Gossipsubv1_2)
+        .peer_kind(PeerKind::Gossipsubv1_2_beta)
         .create_network();
 
     let local_id = PeerId::random();
@@ -5386,7 +5386,7 @@ fn parses_idontwant() {
         .to_subscribe(true)
         .gs_config(Config::default())
         .explicit(1)
-        .peer_kind(PeerKind::Gossipsubv1_2)
+        .peer_kind(PeerKind::Gossipsubv1_2_beta)
         .create_network();
 
     let message_id = MessageId::new(&[0, 1, 2, 3]);
@@ -5418,7 +5418,7 @@ fn clear_stale_idontwant() {
         .to_subscribe(true)
         .gs_config(Config::default())
         .explicit(1)
-        .peer_kind(PeerKind::Gossipsubv1_2)
+        .peer_kind(PeerKind::Gossipsubv1_2_beta)
         .create_network();
 
     let peer = gs.connected_peers.get_mut(&peers[2]).unwrap();


### PR DESCRIPTION
https://github.com/sigp/lighthouse/pull/5422

## Issue Addressed

<!-- Which issue # does this PR address? -->

Test `test_ignore_too_many_messages_in_ihave` is failing in this branch:

https://github.com/sigp/lighthouse/actions/runs/8796045770/job/24138172575
> test behaviour::tests::test_ignore_too_many_messages_in_ihave ... FAILED

Here is the assertion that is failing:

https://github.com/jxs/lighthouse/blob/594698290d4b969be390ec85fdaa4d329b7299e4/beacon_node/lighthouse_network/gossipsub/src/behaviour/tests.rs#L4647


## Proposed Changes

<!-- Please list or describe the changes introduced by this PR. -->

From my investigation, message-ids that are expected to send iwant are being filtered out here, `!self.gossip_promises.contains(id)`:

https://github.com/jxs/lighthouse/blob/0cc18cc15234f2bb023b3be72c3fd19dcceb8445/beacon_node/lighthouse_network/gossipsub/src/behaviour.rs#L1259-L1266

I think this was not intended for this test.

To avoid unexpected filtering, I have changed the test to use fresh message-ids (specifically, `message_ids[20..30]`).



<!--
## Additional Info

Please provide any additional information. For example, future considerations
or information useful for reviewers.
-->