### PR TITLE
Filter boot-node multiaddrs for discv5 eligibility

### DIFF
--- a/beacon_node/lighthouse_network/src/discovery/mod.rs
+++ b/beacon_node/lighthouse_network/src/discovery/mod.rs
@@ -264,47 +264,62 @@ impl<E: EthSpec> Discovery<E> {
             info!("Contacting Multiaddr boot-nodes for their ENR");
         }
 
-        // get futures for requesting the Enrs associated to these multiaddr and wait for their
+        // get futures for requesting the ENRs associated to these multiaddr and wait for their
         // completion
-        let mut fut_coll = config
+        let discv5_eligible_addrs = config
             .boot_nodes_multiaddr
             .iter()
-            .map(|addr| addr.to_string())
-            // request the ENR for this multiaddr and keep the original for logging
-            .map(|addr| {
-                futures::future::join(
-                    discv5.request_enr(addr.clone()),
-                    futures::future::ready(addr),
-                )
-            })
-            .collect::<FuturesUnordered<_>>();
+            // Filter out multiaddrs without UDP or P2P protocols required for discv5 ENR requests
+            .filter(|addr| {
+                addr.iter().any(|proto| matches!(proto, Protocol::Udp(_)))
+                    && addr.iter().any(|proto| matches!(proto, Protocol::P2p(_)))
+            });
 
-        while let Some((result, original_addr)) = fut_coll.next().await {
-            match result {
-                Ok(enr) => {
-                    debug!(
-                        node_id = %enr.node_id(),
-                        peer_id = %enr.peer_id(),
-                        ip4 = ?enr.ip4(),
-                        udp4 = ?enr.udp4(),
-                        tcp4 = ?enr.tcp4(),
-                        quic4 = ?enr.quic4(),
-                        "Adding node to routing table"
-                    );
-                    let _ = discv5.add_enr(enr).map_err(|e| {
-                        error!(
-                            addr = original_addr.to_string(),
-                            error = e.to_string(),
-                            "Could not add peer to the local routing table"
-                        )
-                    });
-                }
-                Err(e) => {
-                    error!(
-                        multiaddr = original_addr.to_string(),
-                        error = e.to_string(),
-                        "Error getting mapping to ENR"
+        if config.disable_discovery {
+            if discv5_eligible_addrs.count() > 0 {
+                warn!(
+                    "Boot node multiaddrs requiring discv5 ENR lookup will be ignored because discovery is disabled"
+                );
+            }
+        } else {
+            let mut fut_coll = discv5_eligible_addrs
+                .map(|addr| addr.to_string())
+                // request the ENR for this multiaddr and keep the original for logging
+                .map(|addr| {
+                    futures::future::join(
+                        discv5.request_enr(addr.clone()),
+                        futures::future::ready(addr),
                     )
+                })
+                .collect::<FuturesUnordered<_>>();
+
+            while let Some((result, original_addr)) = fut_coll.next().await {
+                match result {
+                    Ok(enr) => {
+                        debug!(
+                            node_id = %enr.node_id(),
+                            peer_id = %enr.peer_id(),
+                            ip4 = ?enr.ip4(),
+                            udp4 = ?enr.udp4(),
+                            tcp4 = ?enr.tcp4(),
+                            quic4 = ?enr.quic4(),
+                            "Adding node to routing table"
+                        );
+                        let _ = discv5.add_enr(enr).map_err(|e| {
+                            error!(
+                                addr = original_addr.to_string(),
+                                error = e.to_string(),
+                                "Could not add peer to the local routing table"
+                            )
+                        });
+                    }
+                    Err(e) => {
+                        error!(
+                            multiaddr = original_addr.to_string(),
+                            error = e.to_string(),
+                            "Error getting mapping to ENR"
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
https://github.com/sigp/lighthouse/pull/8683

  - Filter multiaddrs to only those with UDP and P2P protocols required for discv5
  - Add warning when discovery is disabled but discv5-eligible boot-node multiaddrs are provided
